### PR TITLE
Set upToNextMajor to dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftyInAppMessaging",
-    platforms: [.iOS("12.0")],
+    platforms: [.iOS(.v12)],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         .package(name: "Firebase",
                  url: "https://github.com/firebase/firebase-ios-sdk.git",
-                 .exact("8.4.0"))
+                 .upToNextMajor(from: "8.4.0"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
## WHY

- Do not fix Firebase version.
  - Firebase is updated frequently, so minor versions are acceptable.