### PR TITLE
Support 11.0.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" ~> 10.0.0
-binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseInAppMessagingBinary.json" ~> 10.0.0
+binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" ~> 11.0.0
+binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseInAppMessagingBinary.json" ~> 11.0.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" "10.0.0"
-binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseInAppMessagingBinary.json" "10.0.0"
+binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" "11.0.0"
+binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseInAppMessagingBinary.json" "11.0.0"

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,21 +1,21 @@
 {
   "pins" : [
     {
-      "identity" : "abseil-cpp-swiftpm",
+      "identity" : "abseil-cpp-binary",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/abseil-cpp-SwiftPM.git",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
       "state" : {
-        "revision" : "d302de612e3d57c6f4afaf087da18fba8eac72a7",
-        "version" : "0.20220203.1"
+        "revision" : "194a6706acbd25e4ef639bcaddea16e8758a3e27",
+        "version" : "1.2024011602.0"
       }
     },
     {
-      "identity" : "boringssl-swiftpm",
+      "identity" : "app-check",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/firebase/boringssl-SwiftPM.git",
+      "location" : "https://github.com/google/app-check.git",
       "state" : {
-        "revision" : "79db6516894a932d0ddaff3b05b9da1e4f6c4069",
-        "version" : "0.9.0"
+        "revision" : "21fe1af9be463a359aaf8d96789ef73fc3760d09",
+        "version" : "11.0.1"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk.git",
       "state" : {
-        "revision" : "5c4893c55f9d6114e2bb7c691d7ffd81208ac713",
-        "version" : "10.0.0"
+        "revision" : "a5c253d1b4409eb8aef4346015ba000f9935cb2d",
+        "version" : "11.0.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "e3dd02f390cae79a7073b46dfb0cb6b60c48401b",
-        "version" : "10.0.0"
+        "revision" : "ca30c987b732d130732fb60b071e0b655a85ada7",
+        "version" : "11.0.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleDataTransport.git",
       "state" : {
-        "revision" : "5056b15c5acbb90cd214fe4d6138bdf5a740e5a8",
-        "version" : "9.2.0"
+        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
+        "version" : "10.1.0"
       }
     },
     {
@@ -50,17 +50,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "68ea347bdb1a69e2d2ae2e25cd085b6ef92f64cb",
-        "version" : "7.9.0"
+        "revision" : "66dd81c729364b0425d0c2b73e38a489f32b1717",
+        "version" : "8.0.1"
       }
     },
     {
-      "identity" : "grpc-ios",
+      "identity" : "grpc-binary",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/grpc/grpc-ios.git",
+      "location" : "https://github.com/google/grpc-binary.git",
       "state" : {
-        "revision" : "abd2d5a4347efa0454606a788678a5d8ec223738",
-        "version" : "1.44.0-grpc"
+        "revision" : "f56d8fc3162de9a498377c7b6cea43431f4f5083",
+        "version" : "1.65.1"
       }
     },
     {
@@ -68,8 +68,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/gtm-session-fetcher.git",
       "state" : {
-        "revision" : "d4289da23e978f37c344ea6a386e5546e2466294",
-        "version" : "2.1.0"
+        "revision" : "a2ab612cb980066ee56d90d60d8462992c07f24b",
+        "version" : "3.5.0"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "2d12673670417654f08f5f90fdd62926dc3a2648",
+        "version" : "100.0.0"
       }
     },
     {
@@ -86,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/nanopb.git",
       "state" : {
-        "revision" : "819d0a2173aff699fb8c364b6fb906f7cdb1a692",
-        "version" : "2.30909.0"
+        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+        "version" : "2.30910.0"
       }
     },
     {
@@ -95,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/promises.git",
       "state" : {
-        "revision" : "46c1e6b5ac09d8f82c991061c659f67e573d425d",
-        "version" : "2.1.0"
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -7,8 +7,8 @@ let package = Package(
     name: "SwiftyInAppMessaging",
     platforms: [
         .iOS(.v12),
-        .tvOS(.v12),
-        .macOS(.v10_12),
+        .tvOS(.v13),
+        .macOS(.v10_15),
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
@@ -18,7 +18,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/firebase/firebase-ios-sdk", .upToNextMajor(from: .init(10, 0, 0))
+        .package(url: "https://github.com/firebase/firebase-ios-sdk", .upToNextMajor(from: .init(11, 0, 0))
         )
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ func application(_ application: UIApplication, didFinishLaunchWithOptions launch
 
 ## Dependencies
 
-- Firebase iOS SDK == `10.0.0`
+- Firebase iOS SDK == `11.0.0`
 
 ## Installation
 

--- a/Sources/SwiftyInAppMessaging/Default/Banner/InAppDefaultBannerMessageHandler.swift
+++ b/Sources/SwiftyInAppMessaging/Default/Banner/InAppDefaultBannerMessageHandler.swift
@@ -37,7 +37,7 @@
             InAppDefaultBannerMessageHandler.window?.isHidden = false
         }
 
-        func messageDismissed(dismissType: FIRInAppMessagingDismissType) {
+        func messageDismissed(dismissType: InAppMessagingDismissType) {
             self.displayDelegate?.messageDismissed?(
                 self.messageForDisplay, dismissType: dismissType)
             self.dismissView()

--- a/Sources/SwiftyInAppMessaging/Default/Card/InAppDefaultCardMessageHandler.swift
+++ b/Sources/SwiftyInAppMessaging/Default/Card/InAppDefaultCardMessageHandler.swift
@@ -51,7 +51,7 @@
             InAppDefaultCardMessageHandler.window?.isHidden = false
         }
 
-        func messageDismissed(dismissType: FIRInAppMessagingDismissType) {
+        func messageDismissed(dismissType: InAppMessagingDismissType) {
             self.displayDelegate?.messageDismissed?(
                 self.messageForDisplay, dismissType: dismissType)
             self.dismissView()

--- a/Sources/SwiftyInAppMessaging/Default/ImageOnly/InAppDefaultImageOnlyMessageHandler.swift
+++ b/Sources/SwiftyInAppMessaging/Default/ImageOnly/InAppDefaultImageOnlyMessageHandler.swift
@@ -31,7 +31,7 @@
             InAppDefaultImageOnlyMessageHandler.window?.isHidden = false
         }
 
-        func messageDismissed(dismissType: FIRInAppMessagingDismissType) {
+        func messageDismissed(dismissType: InAppMessagingDismissType) {
             self.displayDelegate?.messageDismissed?(
                 self.messageForDisplay, dismissType: dismissType)
             self.dismissView()

--- a/Sources/SwiftyInAppMessaging/Default/Modal/InAppDefaultModalMessageHandler.swift
+++ b/Sources/SwiftyInAppMessaging/Default/Modal/InAppDefaultModalMessageHandler.swift
@@ -38,7 +38,7 @@
             InAppDefaultModalMessageHandler.window?.isHidden = false
         }
 
-        public func messageDismissed(dismissType: FIRInAppMessagingDismissType) {
+        public func messageDismissed(dismissType: InAppMessagingDismissType) {
             self.displayDelegate?.messageDismissed?(
                 self.messageForDisplay, dismissType: dismissType)
             self.dismissView()

--- a/Sources/SwiftyInAppMessaging/InAppMessageHandler.swift
+++ b/Sources/SwiftyInAppMessaging/InAppMessageHandler.swift
@@ -19,7 +19,7 @@
 
     public protocol MessageEventDetectable {
         func impressionDetected()
-        func messageDismissed(dismissType: FIRInAppMessagingDismissType)
+        func messageDismissed(dismissType: InAppMessagingDismissType)
         func messageClicked(with action: InAppMessagingAction)
     }
 
@@ -32,7 +32,7 @@
             self.displayDelegate?.impressionDetected?(for: self.messageForDisplay)
         }
 
-        public func messageDismissed(dismissType: FIRInAppMessagingDismissType) {
+        public func messageDismissed(dismissType: InAppMessagingDismissType) {
             self.displayDelegate?.messageDismissed?(
                 self.messageForDisplay, dismissType: dismissType)
         }
@@ -51,7 +51,7 @@
             self.displayDelegate?.impressionDetected?(for: self.messageForDisplay)
         }
 
-        public func messageDismissed(dismissType: FIRInAppMessagingDismissType) {
+        public func messageDismissed(dismissType: InAppMessagingDismissType) {
             self.displayDelegate?.messageDismissed?(
                 self.messageForDisplay, dismissType: dismissType)
         }
@@ -70,7 +70,7 @@
             self.displayDelegate?.impressionDetected?(for: self.messageForDisplay)
         }
 
-        public func messageDismissed(dismissType: FIRInAppMessagingDismissType) {
+        public func messageDismissed(dismissType: InAppMessagingDismissType) {
             self.displayDelegate?.messageDismissed?(
                 self.messageForDisplay, dismissType: dismissType)
         }
@@ -89,7 +89,7 @@
             self.displayDelegate?.impressionDetected?(for: self.messageForDisplay)
         }
 
-        public func messageDismissed(dismissType: FIRInAppMessagingDismissType) {
+        public func messageDismissed(dismissType: InAppMessagingDismissType) {
             self.displayDelegate?.messageDismissed?(
                 self.messageForDisplay, dismissType: dismissType)
         }

--- a/SwiftyInAppMessaging.podspec
+++ b/SwiftyInAppMessaging.podspec
@@ -36,6 +36,6 @@ Pod::Spec.new do |spec|
 
   spec.static_framework = true
   spec.swift_version = '5.3'
-  spec.dependency "Firebase/InAppMessaging", "~> 10.0.0-beta"
+  spec.dependency "Firebase/InAppMessaging", "~> 11.0.0-beta"
 
 end


### PR DESCRIPTION
## WHAT

- Bump deployment target for each OSs.
- Fix API changes.
    - FIRInAppMessagingDismissType is renamed to InAppMessagingDismissType above 11.0.0